### PR TITLE
Allow upscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ Use the reference values for an app icon, 48px on mdpi :
  5. select densities to export
  6. select image format `png`
 
-Icon or Image resources for all densities will be scaled and written accordingly.
-You will be warned if an image has been upscaled
+
+Icon or Image resources for all densities will be scaled and written
+accordingly, except that by default upscaled images won't be upscaled.  You
+can force creating upscaled images by using the appropiate option.
 
 [![export result](https://lh6.googleusercontent.com/LT7vn7uo2jmjul4ejuu59iM4elDto1TsjagX1Zp5wdgzPghQ_TBsUKGOF65y7m6XwW2DaTpJlxS2GxU9Xi3jklrxj2bR8c6d8blc6dgi8Iwnri56SlM)](https://lh6.googleusercontent.com/LT7vn7uo2jmjul4ejuu59iM4elDto1TsjagX1Zp5wdgzPghQ_TBsUKGOF65y7m6XwW2DaTpJlxS2GxU9Xi3jklrxj2bR8c6d8blc6dgi8Iwnri56SlM)
 

--- a/gimpfu_android_xdpi.py
+++ b/gimpfu_android_xdpi.py
@@ -67,13 +67,6 @@ def write_xdpi(img, layer, res_folder, folder_prefix, image_basename, target_wid
         resize_ratio = float(target_width) / new_img.width
         target_dp_width = target_width
         target_dp_height = round(new_img.height * resize_ratio)
-
-        
-        target_res_folder = os.path.join(res_folder, folder_prefix + '-' + folder)
-        if (os.path.exists(res_folder) and not os.path.exists(target_res_folder)):
-            os.makedirs(target_res_folder)
-            
-        target_res_filename = os.path.join(target_res_folder, image_basename + '.' + image_extension)
         
         # Compute new dimensions for the image
         new_width = target_dp_width * ratio
@@ -89,6 +82,12 @@ def write_xdpi(img, layer, res_folder, folder_prefix, image_basename, target_wid
             else:
                 warnings.append('Resource for %s has been upscaled by %0.2f' %
                             (folder, new_width/new_img.width))
+
+        target_res_folder = os.path.join(res_folder, folder_prefix + '-' + folder)
+        if (os.path.exists(res_folder) and not os.path.exists(target_res_folder)):
+            os.makedirs(target_res_folder)
+
+        target_res_filename = os.path.join(target_res_folder, image_basename + '.' + image_extension)
         
         # Save the new Image
         gimpfu.pdb.gimp_image_scale_full( #@UndefinedVariable

--- a/gimpfu_android_xdpi.py
+++ b/gimpfu_android_xdpi.py
@@ -31,7 +31,7 @@ DEFAULT_FOLDER_PREFIX = 'drawable'
 
 UPSCALE_WARN_MESSAGE = '\nQuality of your application could be seriously affected when using upscaled bitmaps !'
 
-def write_xdpi(img, layer, res_folder, folder_prefix, image_basename, target_width, x_ldpi, x_mdpi, x_hdpi, x_xhdpi, x_xxhdpi, x_xxxhdpi, image_extension):
+def write_xdpi(img, layer, res_folder, folder_prefix, image_basename, target_width, x_ldpi, x_mdpi, x_hdpi, x_xhdpi, x_xxhdpi, x_xxxhdpi, never_upscale, image_extension):
     '''
     Resize and write images for all android density folders 
     
@@ -42,6 +42,7 @@ def write_xdpi(img, layer, res_folder, folder_prefix, image_basename, target_wid
     @param image_basename: basename of your image, ex: icon
     @param target_width: new width for your image
     @param target_dpi: reference density for your target width
+    @param never_upscale: wether to refuse to create upscaled images
     @param image_extension: output format
     '''
     
@@ -81,7 +82,12 @@ def write_xdpi(img, layer, res_folder, folder_prefix, image_basename, target_wid
         print('%s : %dx%d' % (folder, new_width, new_height))
         
         if (new_width>new_img.width):
-            warnings.append('Resource for %s has been upscaled by %0.2f' % 
+            if never_upscale:
+                warnings.append('Not creating resource for %s upscaled by %0.2f' %
+                            (folder, new_width/new_img.width))
+                continue
+            else:
+                warnings.append('Resource for %s has been upscaled by %0.2f' %
                             (folder, new_width/new_img.width))
         
         # Save the new Image
@@ -115,6 +121,7 @@ gimpfu.register("python_fu_android_xdpi",
                     (gimpfu.PF_BOOL, "x_xxhdpi",  "  Export xxhdpi", True),
                     (gimpfu.PF_BOOL, "x_xxxhdpi", "  Export xxxhdpi",False),
                     #(gimpfu.PF_BOOL, "x_tvdpi",   "  Export tvdpi",  False),
+                    (gimpfu.PF_BOOL, "never_upscale", "  Never create upscaled images", True),
                     (gimpfu.PF_RADIO, "image-extension", "Image Format", DEFAULT_OUTPUT_EXT, (("gif", "gif"), ("png", "png"), ("jpg", "jpg"))),
                       ], 
                 [], 

--- a/gimpfu_android_xdpi.py
+++ b/gimpfu_android_xdpi.py
@@ -31,7 +31,7 @@ DEFAULT_FOLDER_PREFIX = 'drawable'
 
 UPSCALE_WARN_MESSAGE = '\nQuality of your application could be seriously affected when using upscaled bitmaps !'
 
-def write_xdpi(img, layer, res_folder, folder_prefix, image_basename, target_width, x_ldpi, x_mdpi, x_hdpi, x_xhdpi, x_xxhdpi, x_xxxhdpi, never_upscale, image_extension):
+def write_xdpi(img, layer, res_folder, folder_prefix, image_basename, target_width, x_ldpi, x_mdpi, x_hdpi, x_xhdpi, x_xxhdpi, x_xxxhdpi, allow_upscale, image_extension):
     '''
     Resize and write images for all android density folders 
     
@@ -42,7 +42,7 @@ def write_xdpi(img, layer, res_folder, folder_prefix, image_basename, target_wid
     @param image_basename: basename of your image, ex: icon
     @param target_width: new width for your image
     @param target_dpi: reference density for your target width
-    @param never_upscale: wether to refuse to create upscaled images
+    @param allow_upscale: whether to create upscaled images
     @param image_extension: output format
     '''
     
@@ -75,7 +75,7 @@ def write_xdpi(img, layer, res_folder, folder_prefix, image_basename, target_wid
         print('%s : %dx%d' % (folder, new_width, new_height))
         
         if (new_width>new_img.width):
-            if never_upscale:
+            if not allow_upscale:
                 warnings.append('Not creating resource for %s upscaled by %0.2f' %
                             (folder, new_width/new_img.width))
                 continue
@@ -120,7 +120,7 @@ gimpfu.register("python_fu_android_xdpi",
                     (gimpfu.PF_BOOL, "x_xxhdpi",  "  Export xxhdpi", True),
                     (gimpfu.PF_BOOL, "x_xxxhdpi", "  Export xxxhdpi",False),
                     #(gimpfu.PF_BOOL, "x_tvdpi",   "  Export tvdpi",  False),
-                    (gimpfu.PF_BOOL, "never_upscale", "  Never create upscaled images", True),
+                    (gimpfu.PF_BOOL, "allow_upscale", "  Create upscaled images", False),
                     (gimpfu.PF_RADIO, "image-extension", "Image Format", DEFAULT_OUTPUT_EXT, (("gif", "gif"), ("png", "png"), ("jpg", "jpg"))),
                       ], 
                 [], 


### PR DESCRIPTION
Added an option to skip image creation when it would result in creating an upscaled image and made that option the default. I think this is a saner default because there's really no point in upscaling images.
